### PR TITLE
emails with smtp.google.com as host

### DIFF
--- a/nx584/mail.py
+++ b/nx584/mail.py
@@ -17,10 +17,10 @@ def _send_system_email(config, subject, recips, body):
     try:
         fromaddr = config.get('email', 'fromaddr')
         smtphost = config.get('email', 'smtphost')
+        password = config.get('email', 'password')
     except (configparser.NoOptionError,
             configparser.NoSectionError):
         raise MissingEmailConfig()
-
     msg = email.mime.text.MIMEText(body)
     msg['Subject'] = subject
     msg['From'] = fromaddr
@@ -28,8 +28,9 @@ def _send_system_email(config, subject, recips, body):
     msg['Message-Id'] = email.utils.make_msgid('nx584')
     for addr in recips:
         msg['To'] = addr
-
-    smtp = smtplib.SMTP(smtphost)
+    smtp = smtplib.SMTP('smtp.gmail.com: 587')
+    smtp.starttls()
+    smtp.login(fromaddr, password)
     smtp.sendmail(fromaddr, recips, msg.as_string())
     smtp.quit()
 
@@ -126,8 +127,7 @@ def send_log_event_mail(config, event):
 
     try:
         alarm_events = set(config.get('email', 'alarm_events').split(','))
-    except (configparser.NoOptionError, configparser.NoSectionError):
-        alarm_events = set(['Alarm', 'Alarm restore', 'Manual fire',])
+    except (configparser.NoOptionError, configparser.NoSectionError):a_
 
     try:
         event_emails = set(config.get('email', 'events').split(','))


### PR DESCRIPTION
I was able to get email notifications working with some changes in mail.py which are shown below. There remains one problem. The reported zone which triggers the alarm is one less than the actual zone, for instance, if I trigger zone 2, the email message reports zone 1. I have confirmed this with triggering 6 other zones.

My example config.ini file below shows that you must provide:

Email addresses for recipients, either as system or alarms. With system, you get emails when nx584 starts, and when the global siren asserts or de-asserts. With alarms, you get emails when alarm is triggered telling you zone and alarm triggered or restored. I will be using the alarms recipient. You can provide multiple emails separated by commas, or your as a text msg if you provider allows, with Verizon its phonenumber@vtext.com.

Smtphost which is smtp.gmail.com. You will need to set up google smtp which forwards your emails from your alarm. I made dedicated gmail account for my alarm. Be sure to set up two factor authorization with your account and create a application password for your google account. Use your application password for "password" entry in the config.ini file. https://www.hostinger.com/tutorials/how-to-use-free-google-smtp-server.

I tested by alarm gmail smtp by installing msmtp https://www.techrapid.uk/2017/04/send-email-on-raspberry-pi-with-msmtp.html.

sample emails from alarm are at the end of the post

config.ini"

[config]
max_zone = 32
[email]
fromaddr = YourAlarmEmail@gmail.com
smtphost = smtp.gmail.com
password = YourAlarmGmailPassword
alarms = recipient1Email.com, recipient2Email.com, phonenumber@vtext.com
#system = recipient1Email.com #(uncomment if you want system emails)
[zones]
1 = GARAGE INT DR
2 = GREAT RM MOTION
3 = BSMT DEN MOTION
4 = FRONT DOOR
etc